### PR TITLE
Potential fix for code scanning alert no. 2: Unbounded write

### DIFF
--- a/sample.c
+++ b/sample.c
@@ -11,6 +11,6 @@ int main(int argc, char** argv) {
         return -1;
     }
     char cmd[BUFSIZE] = "wc -c < ";
-    strcat(cmd, argv[1]);
+    strncat(cmd, argv[1], BUFSIZE - strlen(cmd) - 1);
     system(cmd);
 }

--- a/sample.c
+++ b/sample.c
@@ -10,7 +10,7 @@ int main(int argc, char** argv) {
         fprintf(stderr, "Please provide the address of a file as an input.\n");
         return -1;
     }
-    char cmd[BUFSIZE] = "wc -c < ";
-    strncat(cmd, argv[1], BUFSIZE - strlen(cmd) - 1);
+    char cmd[BUFSIZE];
+    snprintf(cmd, BUFSIZE, "wc -c < %s", argv[1]);
     system(cmd);
 }


### PR DESCRIPTION
Potential fix for [https://github.com/Astatine-213-Tian/CS489-CodeQL/security/code-scanning/2](https://github.com/Astatine-213-Tian/CS489-CodeQL/security/code-scanning/2)

To fix the problem, we need to ensure that the concatenation of the command-line argument to the buffer does not exceed the buffer's size. We can achieve this by using the `strncat` function, which allows us to specify the maximum number of characters to concatenate. This way, we can ensure that the buffer size is not exceeded.

Specifically, we will replace the `strcat` call with `strncat`, and calculate the maximum number of characters to concatenate based on the buffer size and the length of the existing content in the buffer. We will also ensure that the buffer is null-terminated.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
